### PR TITLE
Update Main_Control.ipynb

### DIFF
--- a/Main_Control.ipynb
+++ b/Main_Control.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "import torch\n",
     "import sys\n",
-    "sys.path.append('MOSAIC/PredictionUtils') # This is where the library is located\n",
+    "sys.path.append('PredictionUtils') # This is where the library is located\n",
     "\n",
     "from Transformation_Model import KernelMetricNetwork\n",
     "from ChemUtils import create_rxn_Mix_FP,show_rxn,show_mol\n",
@@ -190,7 +190,7 @@
     "            \n",
     "                 \n",
     "            config = {\n",
-    "                      'HF_HOME_PATH':HF_HOME_Directory',\n",
+    "                      'HF_HOME_PATH':HF_HOME_Directory,\n",
     "                      'base_model_path': base_model_path,\n",
     "                      'finetune_adaptor_path': expert_adapter_path,\n",
     "                      'rxn':rxn,\n",


### PR DESCRIPTION
If starting jupiter from core directory of the project, such a path to PredictionUtils did work for me instead of original. 

After HF_HOME_Directory, there is an extra ' (single quote) in the dictionary definition.

I will look futher and try fix issues, if i will find some.